### PR TITLE
chore: add access tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,12 +123,14 @@ You need the following permissions to run this module.
 | [ibm_event_streams_topic.es_topic](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/event_streams_topic) | resource |
 | [ibm_iam_authorization_policy.kms_policy](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/iam_authorization_policy) | resource |
 | [ibm_resource_instance.es_instance](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/resource_instance) | resource |
+| [ibm_resource_tag.es_access_tag](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/resource_tag) | resource |
 | [time_sleep.wait_for_authorization_policy](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 
 ### Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_access_tags"></a> [access\_tags](#input\_access\_tags) | The list of access tags associated with the Event Streams instance. | `list(string)` | `[]` | no |
 | <a name="input_cbr_rules"></a> [cbr\_rules](#input\_cbr\_rules) | The list of context-based restriction rules to create. | <pre>list(object({<br/>    description = string<br/>    account_id  = string<br/>    rule_contexts = list(object({<br/>      attributes = optional(list(object({<br/>        name  = string<br/>        value = string<br/>    }))) }))<br/>    enforcement_mode = string<br/>  }))</pre> | `[]` | no |
 | <a name="input_create_timeout"></a> [create\_timeout](#input\_create\_timeout) | The timeout value for creating an Event Streams instance. Specify `3h` for an Enterprise plan instance. Add 1 h for each level of non-default throughput. Add 30 min for each level of non-default storage size. | `string` | `"3h"` | no |
 | <a name="input_delete_timeout"></a> [delete\_timeout](#input\_delete\_timeout) | The timeout value for deleting an Event Streams instance. | `string` | `"15m"` | no |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -59,6 +59,7 @@ module "event_streams" {
   es_name           = "${var.prefix}-es"
   schemas           = var.schemas
   tags              = var.resource_tags
+  access_tags       = var.access_tags
   topics            = var.topics
   cbr_rules = [
     {

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -28,6 +28,12 @@ variable "resource_tags" {
   default     = []
 }
 
+variable "access_tags" {
+  type        = list(string)
+  description = "The list of access tags associated with the Event Steams instance."
+  default     = []
+}
+
 variable "schemas" {
   type = list(object(
     {

--- a/main.tf
+++ b/main.tf
@@ -79,6 +79,16 @@ resource "ibm_event_streams_topic" "es_topic" {
 }
 
 ##############################################################################
+# ACCESS TAGS - attaching existing access tags to the resource instance
+##############################################################################
+resource "ibm_resource_tag" "es_access_tag" {
+  count       = length(var.access_tags) > 0 ? 1 : 0
+  resource_id = ibm_resource_instance.es_instance.id
+  tags        = var.access_tags
+  tag_type    = "access"
+}
+
+##############################################################################
 # IAM Authorization Policy
 ##############################################################################
 

--- a/modules/fscloud/README.md
+++ b/modules/fscloud/README.md
@@ -26,6 +26,7 @@ No resources.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_access_tags"></a> [access\_tags](#input\_access\_tags) | The list of access tags associated with the Event Steams instance. | `list(string)` | `[]` | no |
 | <a name="input_cbr_rules"></a> [cbr\_rules](#input\_cbr\_rules) | The list of context-based restriction rules to create. | <pre>list(object({<br/>    description = string<br/>    account_id  = string<br/>    rule_contexts = list(object({<br/>      attributes = optional(list(object({<br/>        name  = string<br/>        value = string<br/>    }))) }))<br/>    enforcement_mode = string<br/>  }))</pre> | `[]` | no |
 | <a name="input_es_name"></a> [es\_name](#input\_es\_name) | The name of the Event Streams instance. | `string` | n/a | yes |
 | <a name="input_existing_kms_instance_guid"></a> [existing\_kms\_instance\_guid](#input\_existing\_kms\_instance\_guid) | The GUID of the Hyper Protect Crypto service in which the key specified in var.kms\_key\_crn is coming from | `string` | n/a | yes |

--- a/modules/fscloud/main.tf
+++ b/modules/fscloud/main.tf
@@ -8,6 +8,7 @@ module "event_streams" {
   existing_kms_instance_guid = var.existing_kms_instance_guid
   schemas                    = var.schemas
   tags                       = var.tags
+  access_tags                = var.access_tags
   topics                     = var.topics
   service_endpoints          = "private"
   cbr_rules                  = var.cbr_rules

--- a/modules/fscloud/variables.tf
+++ b/modules/fscloud/variables.tf
@@ -11,6 +11,12 @@ variable "tags" {
   default     = []
 }
 
+variable "access_tags" {
+  type        = list(string)
+  description = "The list of access tags associated with the Event Steams instance."
+  default     = []
+}
+
 variable "es_name" {
   description = "The name of the Event Streams instance."
   type        = string

--- a/solutions/quickstart/main.tf
+++ b/solutions/quickstart/main.tf
@@ -19,4 +19,5 @@ module "event_streams" {
   region            = var.region
   topics            = var.topics
   tags              = var.resource_tags
+  access_tags       = var.access_tags
 }

--- a/solutions/quickstart/variables.tf
+++ b/solutions/quickstart/variables.tf
@@ -40,6 +40,12 @@ variable "resource_tags" {
   default     = []
 }
 
+variable "access_tags" {
+  type        = list(string)
+  description = "The list of access tags associated with the Event Streams instance."
+  default     = []
+}
+
 variable "plan" {
   type        = string
   description = "The plan for the Event Streams instance. Possible values: `lite` and `standard`."

--- a/variables.tf
+++ b/variables.tf
@@ -28,6 +28,12 @@ variable "tags" {
   default     = []
 }
 
+variable "access_tags" {
+  type        = list(string)
+  description = "The list of access tags associated with the Event Streams instance."
+  default     = []
+}
+
 variable "region" {
   type        = string
   description = "The region where the Event Streams are created."


### PR DESCRIPTION
Add association of access tags (https://cloud.ibm.com/docs/account?topic=account-access-tags-tutorial) with the Event Streams instance. Updates the main module, examples/complete, modules/fscloud, and solutions/quickstart, plus READMEs.

### Description

Add access tags to the module. This is a customer-requested feature.

Access tags are already in the IBM terraform provider, so no update to the version is needed.

### Release required?

- [x] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

### Run the pipeline

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
