### PR TITLE
feat: exposed timeouts inputs in the enterprise DA + add upgrade test for enterprise DA

### DIFF
--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -287,6 +287,15 @@
               "key": "access_tags"
             },
             {
+              "key": "create_timeout"
+            },
+            {
+              "key": "delete_timeout"
+            },
+            {
+              "key": "update_timeout"
+            },
+            {
               "key": "schemas"
             },
             {

--- a/modules/fscloud/README.md
+++ b/modules/fscloud/README.md
@@ -28,6 +28,8 @@ No resources.
 |------|-------------|------|---------|:--------:|
 | <a name="input_access_tags"></a> [access\_tags](#input\_access\_tags) | The list of access tags associated with the Event Steams instance. | `list(string)` | `[]` | no |
 | <a name="input_cbr_rules"></a> [cbr\_rules](#input\_cbr\_rules) | The list of context-based restriction rules to create. | <pre>list(object({<br/>    description = string<br/>    account_id  = string<br/>    rule_contexts = list(object({<br/>      attributes = optional(list(object({<br/>        name  = string<br/>        value = string<br/>    }))) }))<br/>    enforcement_mode = string<br/>  }))</pre> | `[]` | no |
+| <a name="input_create_timeout"></a> [create\_timeout](#input\_create\_timeout) | The timeout value for creating an Event Streams instance. Specify `3h` for an Enterprise plan instance. Add 1 h for each level of non-default throughput. Add 30 min for each level of non-default storage size. | `string` | `"3h"` | no |
+| <a name="input_delete_timeout"></a> [delete\_timeout](#input\_delete\_timeout) | The timeout value for deleting an Event Streams instance. | `string` | `"15m"` | no |
 | <a name="input_es_name"></a> [es\_name](#input\_es\_name) | The name of the Event Streams instance. | `string` | n/a | yes |
 | <a name="input_kms_key_crn"></a> [kms\_key\_crn](#input\_kms\_key\_crn) | The root key CRN of the key management service (Key Protect or Hyper Protect Crypto Services) to use to encrypt the payload data. | `string` | n/a | yes |
 | <a name="input_metrics"></a> [metrics](#input\_metrics) | Enhanced metrics to activate, as list of strings. Allowed values: 'topic', 'partition', 'consumers'. | `list(string)` | `[]` | no |
@@ -43,6 +45,7 @@ No resources.
 | <a name="input_skip_kms_iam_authorization_policy"></a> [skip\_kms\_iam\_authorization\_policy](#input\_skip\_kms\_iam\_authorization\_policy) | Set to true to skip the creation of an IAM authorization policy that permits all Event Streams database instances in the resource group to read the encryption key from the KMS instance. If set to false, pass in a value for the KMS instance in the kms\_key\_crn variable. In addition, no policy is created if var.kms\_encryption\_enabled is set to false. | `bool` | `false` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | The list of tags associated with the Event Steams instance. | `list(string)` | `[]` | no |
 | <a name="input_topics"></a> [topics](#input\_topics) | The list of topics to apply to resources. Only one topic is allowed for Lite plan instances. | <pre>list(object(<br/>    {<br/>      name       = string<br/>      partitions = number<br/>      config     = map(string)<br/>    }<br/>  ))</pre> | `[]` | no |
+| <a name="input_update_timeout"></a> [update\_timeout](#input\_update\_timeout) | The timeout value for updating an Event Streams instance. Specify `1h` for an Enterprise plan instance. Add 1 h for each level of non-default throughput. A 30 min for each level of non-default storage size. | `string` | `"1h"` | no |
 
 ### Outputs
 

--- a/modules/fscloud/main.tf
+++ b/modules/fscloud/main.tf
@@ -20,4 +20,7 @@ module "event_streams" {
   kms_encryption_enabled               = true
   mirroring_topic_patterns             = var.mirroring_topic_patterns
   mirroring                            = var.mirroring
+  create_timeout                       = var.create_timeout
+  update_timeout                       = var.update_timeout
+  delete_timeout                       = var.delete_timeout
 }

--- a/modules/fscloud/variables.tf
+++ b/modules/fscloud/variables.tf
@@ -162,3 +162,21 @@ variable "mirroring" {
   })
   default = null
 }
+
+variable "create_timeout" {
+  type        = string
+  description = "The timeout value for creating an Event Streams instance. Specify `3h` for an Enterprise plan instance. Add 1 h for each level of non-default throughput. Add 30 min for each level of non-default storage size."
+  default     = "3h"
+}
+
+variable "update_timeout" {
+  type        = string
+  description = "The timeout value for updating an Event Streams instance. Specify `1h` for an Enterprise plan instance. Add 1 h for each level of non-default throughput. A 30 min for each level of non-default storage size."
+  default     = "1h"
+}
+
+variable "delete_timeout" {
+  type        = string
+  description = "The timeout value for deleting an Event Streams instance."
+  default     = "15m"
+}

--- a/solutions/enterprise/main.tf
+++ b/solutions/enterprise/main.tf
@@ -161,4 +161,7 @@ module "event_streams" {
   schema_global_rule                   = var.schema_global_rule
   skip_kms_iam_authorization_policy    = var.skip_event_streams_kms_auth_policy
   skip_es_s2s_iam_authorization_policy = var.skip_event_streams_s2s_iam_auth_policy
+  create_timeout                       = var.create_timeout
+  update_timeout                       = var.update_timeout
+  delete_timeout                       = var.delete_timeout
 }

--- a/solutions/enterprise/variables.tf
+++ b/solutions/enterprise/variables.tf
@@ -252,3 +252,21 @@ variable "ibmcloud_kms_api_key" {
   sensitive   = true
   default     = null
 }
+
+variable "create_timeout" {
+  type        = string
+  description = "The timeout value for creating an Event Streams instance. Specify `3h` for an Enterprise plan instance. Add 1 h for each level of non-default throughput. Add 30 min for each level of non-default storage size."
+  default     = "3h"
+}
+
+variable "update_timeout" {
+  type        = string
+  description = "The timeout value for updating an Event Streams instance. Specify `1h` for an Enterprise plan instance. Add 1 h for each level of non-default throughput. A 30 min for each level of non-default storage size."
+  default     = "1h"
+}
+
+variable "delete_timeout" {
+  type        = string
+  description = "The timeout value for deleting an Event Streams instance."
+  default     = "15m"
+}

--- a/tests/other_test.go
+++ b/tests/other_test.go
@@ -6,16 +6,63 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/terraform-ibm-modules/ibmcloud-terratest-wrapper/testschematic"
 )
 
 const basicExampleTerraformDir = "examples/basic"
 
-func TestRunDefaultExample(t *testing.T) {
+func TestRunBasicExample(t *testing.T) {
 	t.Parallel()
 
-	options := setupOptions(t, "event-streams-default", basicExampleTerraformDir)
+	options := setupOptions(t, "event-streams-bsc", basicExampleTerraformDir)
 
 	output, err := options.RunTestConsistency()
 	assert.Nil(t, err, "This should not have errored")
 	assert.NotNil(t, output, "Expected some output")
+}
+
+func TestRunCompleteExample(t *testing.T) {
+	t.Parallel()
+
+	options := setupOptions(t, "event-streams-bsc", completeExampleTerraformDir)
+
+	output, err := options.RunTestConsistency()
+	assert.Nil(t, err, "This should not have errored")
+	assert.NotNil(t, output, "Expected some output")
+}
+
+func TestFSCloudInSchematics(t *testing.T) {
+	t.Parallel()
+
+	options := testschematic.TestSchematicOptionsDefault(&testschematic.TestSchematicOptions{
+		Testing:            t,
+		Prefix:             "es-fscloud",
+		BestRegionYAMLPath: regionSelectionPath,
+		TarIncludePatterns: []string{
+			"*.tf",
+			fsCloudTerraformDir + "/*.tf",
+			"modules/fscloud/*.tf",
+		},
+		/*
+			Comment out the 'ResourceGroup' input to force this tests to create a unique resource group to ensure tests do
+			not clash. This is due to the fact that an auth policy may already exist in this resource group since we are
+			re-using a permanent HPCS instance and a permanent Event Streams instance. By using a new resource group, the auth policy will not already exist
+			since this module scopes auth policies by resource group.
+		*/
+		//ResourceGroup:      resourceGroup,
+		TemplateFolder:         fsCloudTerraformDir,
+		Tags:                   []string{"test-schematic"},
+		DeleteWorkspaceOnFail:  false,
+		WaitJobCompleteMinutes: 180,
+	})
+
+	options.TerraformVars = []testschematic.TestSchematicTerraformVar{
+		{Name: "ibmcloud_api_key", Value: options.RequiredEnvironmentVars["TF_VAR_ibmcloud_api_key"], DataType: "string", Secure: true},
+		{Name: "prefix", Value: options.Prefix, DataType: "string"},
+		{Name: "kms_key_crn", Value: permanentResources["hpcs_south_root_key_crn"].(string), DataType: "string"},
+		{Name: "event_streams_source_crn", Value: permanentResources["event_streams_us_south_crn"].(string), DataType: "string"},
+	}
+
+	err := options.RunSchematicTest()
+	assert.Nil(t, err, "This should not have errored")
 }

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -93,7 +93,7 @@ func setupEnterpriseOptions(t *testing.T, prefix string) *testschematic.TestSche
 		TemplateFolder:         enterpriseSolutionTerraformDir,
 		Tags:                   []string{"test-schematic"},
 		DeleteWorkspaceOnFail:  false,
-		WaitJobCompleteMinutes: 180,
+		WaitJobCompleteMinutes: 360,
 	})
 
 	options.TerraformVars = []testschematic.TestSchematicTerraformVar{
@@ -105,6 +105,8 @@ func setupEnterpriseOptions(t *testing.T, prefix string) *testschematic.TestSche
 		{Name: "existing_kms_instance_crn", Value: permanentResources["hpcs_south_crn"], DataType: "string"},
 		{Name: "access_tags", Value: permanentResources["accessTags"], DataType: "list(string)"},
 		{Name: "resource_tags", Value: options.Tags, DataType: "list(string)"},
+		// Update the create timeout as it can take longer than the default (3 hours) when running multiple tests in parallel
+		{Name: "create_timeout", Value: "5h", DataType: "string"},
 	}
 	return options
 }

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -50,18 +50,6 @@ func setupOptions(t *testing.T, prefix string, dir string) *testhelper.TestOptio
 	return options
 }
 
-func TestRunUpgradeExample(t *testing.T) {
-	t.Parallel()
-
-	options := setupOptions(t, "event-streams-upg", completeExampleTerraformDir)
-
-	output, err := options.RunTestUpgrade()
-	if !options.UpgradeTestSkipped {
-		assert.Nil(t, err, "This should not have errored")
-		assert.NotNil(t, output, "Expected some output")
-	}
-}
-
 func TestRunQuickstartSolution(t *testing.T) {
 	t.Parallel()
 
@@ -85,12 +73,10 @@ func TestRunQuickstartSolution(t *testing.T) {
 	assert.NotNil(t, output, "Expected some output")
 }
 
-func TestEnterpriseSolutionInSchematics(t *testing.T) {
-	t.Parallel()
-
+func setupEnterpriseOptions(t *testing.T, prefix string) *testschematic.TestSchematicOptions {
 	options := testschematic.TestSchematicOptionsDefault(&testschematic.TestSchematicOptions{
 		Testing:            t,
-		Prefix:             "es-ent",
+		Prefix:             prefix,
 		BestRegionYAMLPath: regionSelectionPath,
 		TarIncludePatterns: []string{
 			"*.tf",
@@ -120,43 +106,25 @@ func TestEnterpriseSolutionInSchematics(t *testing.T) {
 		{Name: "access_tags", Value: permanentResources["accessTags"], DataType: "list(string)"},
 		{Name: "resource_tags", Value: options.Tags, DataType: "list(string)"},
 	}
+	return options
+}
 
+// Test for the Enterprise DA
+func TestEnterpriseSolutionInSchematics(t *testing.T) {
+	t.Parallel()
+
+	options := setupEnterpriseOptions(t, "es-ent")
 	err := options.RunSchematicTest()
 	assert.Nil(t, err, "This should not have errored")
 }
 
-func TestFSCloudInSchematics(t *testing.T) {
+// Upgrade test for the Enterprise DA
+func TestRunUpgradeEnterpriseDA(t *testing.T) {
 	t.Parallel()
 
-	options := testschematic.TestSchematicOptionsDefault(&testschematic.TestSchematicOptions{
-		Testing:            t,
-		Prefix:             "es-fscloud",
-		BestRegionYAMLPath: regionSelectionPath,
-		TarIncludePatterns: []string{
-			"*.tf",
-			fsCloudTerraformDir + "/*.tf",
-			"modules/fscloud/*.tf",
-		},
-		/*
-			Comment out the 'ResourceGroup' input to force this tests to create a unique resource group to ensure tests do
-			not clash. This is due to the fact that an auth policy may already exist in this resource group since we are
-			re-using a permanent HPCS instance and a permanent Event Streams instance. By using a new resource group, the auth policy will not already exist
-			since this module scopes auth policies by resource group.
-		*/
-		//ResourceGroup:      resourceGroup,
-		TemplateFolder:         fsCloudTerraformDir,
-		Tags:                   []string{"test-schematic"},
-		DeleteWorkspaceOnFail:  false,
-		WaitJobCompleteMinutes: 180,
-	})
-
-	options.TerraformVars = []testschematic.TestSchematicTerraformVar{
-		{Name: "ibmcloud_api_key", Value: options.RequiredEnvironmentVars["TF_VAR_ibmcloud_api_key"], DataType: "string", Secure: true},
-		{Name: "prefix", Value: options.Prefix, DataType: "string"},
-		{Name: "kms_key_crn", Value: permanentResources["hpcs_south_root_key_crn"].(string), DataType: "string"},
-		{Name: "event_streams_source_crn", Value: permanentResources["event_streams_us_south_crn"].(string), DataType: "string"},
+	options := setupEnterpriseOptions(t, "ev-st-upg")
+	err := options.RunSchematicUpgradeTest()
+	if !options.UpgradeTestSkipped {
+		assert.Nil(t, err, "This should not have errored")
 	}
-
-	err := options.RunSchematicTest()
-	assert.Nil(t, err, "This should not have errored")
 }


### PR DESCRIPTION
### Description

- moved tests that run examples to other_test.go
- created new upgrade test for enterprise DA
- exposed timeouts inputs in the enterprise DA

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [x] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
