### PR TITLE
test: update timeout to 6 hours

### DIFF
--- a/examples/fscloud/main.tf
+++ b/examples/fscloud/main.tf
@@ -76,6 +76,7 @@ module "event_streams" {
   schemas                  = var.schemas
   tags                     = var.resource_tags
   topics                   = var.topics
+  create_timeout           = "6h"
   metrics                  = ["topic", "partition", "consumers"]
   mirroring_topic_patterns = ["topic-1", "topic-2"]
   mirroring = {

--- a/solutions/enterprise/catalogValidationValues.json.template
+++ b/solutions/enterprise/catalogValidationValues.json.template
@@ -4,5 +4,5 @@
   "prefix": $PREFIX,
   "resource_group_name": $PREFIX,
   "existing_kms_instance_crn": $HPCS_US_SOUTH_CRN,
-  "create_timeout": "5h"
+  "create_timeout": "6h"
 }

--- a/tests/other_test.go
+++ b/tests/other_test.go
@@ -53,7 +53,7 @@ func TestFSCloudInSchematics(t *testing.T) {
 		TemplateFolder:         fsCloudTerraformDir,
 		Tags:                   []string{"test-schematic"},
 		DeleteWorkspaceOnFail:  false,
-		WaitJobCompleteMinutes: 180,
+		WaitJobCompleteMinutes: 420,
 	})
 
 	options.TerraformVars = []testschematic.TestSchematicTerraformVar{

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -148,7 +148,7 @@ func setupEnterpriseOptions(t *testing.T, prefix string) *testschematic.TestSche
 		{Name: "access_tags", Value: permanentResources["accessTags"], DataType: "list(string)"},
 		{Name: "resource_tags", Value: options.Tags, DataType: "list(string)"},
 		// Update the create timeout as it can take longer than the default (3 hours) when running multiple tests in parallel
-		{Name: "create_timeout", Value: "5h", DataType: "string"},
+		{Name: "create_timeout", Value: "6h", DataType: "string"},
 		{Name: "existing_secrets_manager_instance_crn", Value: permanentResources["secretsManagerCRN"], DataType: "string"},
 		{Name: "service_credential_secrets", Value: serviceCredentialSecrets, DataType: "list(object)"},
 	}


### PR DESCRIPTION
### Description

It was recommended by ES team to increase the timeout for our account since we are allowlisted to provision enterprise instances in parallel

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [x] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
