### PR TITLE
fix: false type in conditional operation

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -70,9 +70,11 @@ locals {
 ##############################################################################
 
 resource "ibm_event_streams_schema" "es_schema" {
-  for_each = var.plan == "enterprise-3nodes-2tb" ? {
-    for schema in var.schemas : schema.schema_id => schema
-  } : {}
+  for_each = {
+    for schema in var.schemas :
+    schema.schema_id => schema
+    if var.plan == "enterprise-3nodes-2tb"
+  }
 
   resource_instance_id = ibm_resource_instance.es_instance.id
   schema_id            = each.value.schema_id


### PR DESCRIPTION
### Description

The false expression in the schema block conditional expression's type is not correct.
issue: https://github.com/terraform-ibm-modules/terraform-ibm-event-streams/issues/546

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [X] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

Fixes the type of the false expression error in the schema block.

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
